### PR TITLE
allow for iperf3 target ports to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This can be also be limited by the `iperf3.timeout` command-line flag. If neithe
 ## Prometheus Configuration
 
 The iPerf3 exporter needs to be passed the target as a parameter, this can be done with relabelling.
+Optional: pass the port that the target iperf3 server is lisenting on as the "port" parameter.
 
 Example config:
 ```yml


### PR DESCRIPTION
Added support for a new parameter "port" to be passed to the exporter.  
This will allow for non-default ports to be used on iperf3 targets.  If the parameter is not passed the exporter will specify the default port of 5201 in the port flag when calling iperf3.