### PR TITLE
Add reverse_mode GET param to trigger `-R` passed to iperf3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.*
+Dockerfile
+LICENSE*
+NOTICE*
+README*
+iperf3_windows.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
+FROM golang:alpine AS build-env
+
+# Download dependencies
+WORKDIR /go/src
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Build current sources
+COPY . .
+RUN go build -o /go/bin/iperf3_exporter
+
+# Prepare runtime environment
 FROM alpine:latest
 LABEL maintainer="Edgard Castro <edgardcastro@gmail.com>"
-
+EXPOSE 9579
 RUN apk add --no-cache iperf3
-COPY iperf3_exporter /bin/iperf3_exporter
-
+COPY --from=build-env /go/bin/iperf3_exporter /bin/
 ENTRYPOINT ["/bin/iperf3_exporter"]
-EXPOSE     9579

--- a/iperf3_exporter.go
+++ b/iperf3_exporter.go
@@ -112,12 +112,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 	defer cancel()
 
-	var iperfArgs []interface{}
-	iperfArgs = []interface{}{iperfCmd, "-J", "-t", strconv.FormatFloat(e.period.Seconds(), 'f', 0, 64), "-c", e.target, "-p", strconv.Itoa(e.port)}
+	var iperfArgs []string
+	iperfArgs = []string{"-J", "-t", strconv.FormatFloat(e.period.Seconds(), 'f', 0, 64), "-c", e.target, "-p", strconv.Itoa(e.port)}
 	if e.reverse{
 		iperfArgs = append(iperfArgs, "-R")
 	}
-	out, err := exec.CommandContext(ctx, iperfArgs...).Output()
+	out, err := exec.CommandContext(ctx, iperfCmd, iperfArgs...).Output()
 	if err != nil {
 		ch <- prometheus.MustNewConstMetric(e.success, prometheus.GaugeValue, 0)
 		iperfErrors.Inc()


### PR DESCRIPTION
This allows people to test downstream to the exporter host from the iperf server.

Test: `docker build -t iperf3_exporter:cooper .`

Attempts to fix #8 