### PR TITLE
Add optional bitrate HTTP parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ This can be also be limited by the `iperf3.timeout` command-line flag. If neithe
 ## Prometheus Configuration
 
 The iPerf3 exporter needs to be passed the target as a parameter, this can be done with relabelling.
-Optional: pass the port that the target iperf3 server is lisenting on as the "port" parameter.
+Optional: 
+  - pass the port that the target iperf3 server is lisenting on as the "port" parameter.
+  - pass the target bitrate ( #[KMG][/#]) as the "bitrate" parameter, default is unlimited.
 
 Example config:
 ```yml


### PR DESCRIPTION
This allows to additionally set --bitrate **iperf3** flag that can limit bitrate used for testing. This can be particularly helpful for testing channels for minimally accepted real bandwidth on regular basis to avoid real users interference:

iperf3 --help
...
  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)
                            (default 1 Mbit/sec for UDP, unlimited for TCP)
                            (optional slash and packet count for burst mode)
...

It can be set like this:

```
    - name: iperf3_exporter
      scrape_configs:
        - job_name: 'iperf3'
          metrics_path: /probe
          scrape_interval: 15m
          static_configs:
            - targets:
                 - xyz.example
          params:
            bitrate: 10M
            port: ['5201']
          relabel_configs:
            - source_labels: [__address__]
              target_label: __param_target
            - source_labels: [__param_target]
              target_label: instance
            - target_label: __address__
              replacement: "localhost:9579"
```